### PR TITLE
Fixed SNMPAgent crash issue when queried for unknown OID

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-snmp], [1.2.3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-snmp], [1.2.4], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-snmp (1.2.4) unstable; urgency=medium
+
+  * Bugfix: Fixed SNMPAgent crash issue when queried for unknown OID 
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 19 Mar 2020 22:34:40 -0700
+
 opx-snmp (1.2.3) unstable; urgency=medium
 
   * Bugfix: Fixed issue where OID not increasing during snmpwalk of interface MIB

--- a/sbin/SNMPAgent
+++ b/sbin/SNMPAgent
@@ -224,15 +224,15 @@ class SNMPAgent:
 
                 handler_key = module[0:2]
                 if not all(module):
-                    raise error.NoSuchInstanceError(name=name)
+                    raise error.NoSuchInstanceError(name=name, idx=idx)
                 else:
                     if handler_key not in agent_handlers:
-                        raise error.NoSuchObjectError(name=name)
+                        raise error.NoSuchObjectError(name=name, idx=idx)
 
                     ret = agent_handlers[handler_key][0](module[0],
                             name)
                     if ret is None:
-                        raise error.NoSuchInstanceError(name=name)
+                        raise error.NoSuchInstanceError(name=name, idx=idx)
                     else:
                         return ret
 
@@ -244,7 +244,7 @@ class SNMPAgent:
                 handler_key = module[0:2]
 
                 if handler_key not in agent_handlers:
-                    raise error.NoSuchObjectError(name=name)
+                    raise error.NoSuchObjectError(name=name, idx=idx)
 
                 if not all(module):
                     ret = agent_handlers[handler_key][1](module[0],
@@ -254,7 +254,7 @@ class SNMPAgent:
                             name)
 
                 if ret is None:
-                    raise error.NoSuchInstanceError(name=name)
+                    raise error.NoSuchInstanceError(name=name, idx=idx)
                 else:
                     return ret
 


### PR DESCRIPTION
#10

Error object instances from smi.error are expected to have idx value
Added the idx value for Error instances raised in SNMPAgent
